### PR TITLE
HMM_Paper

### DIFF
--- a/benchmarks/vector_ping_pong/CMakeLists.txt
+++ b/benchmarks/vector_ping_pong/CMakeLists.txt
@@ -4,8 +4,8 @@ project(vector_ping_pong CXX)
 include(FetchContent)
 FetchContent_Declare(
     Kokkos
-    URL      https://github.com/kokkos/kokkos/releases/download/5.0.0/kokkos-5.0.0.tar.gz
-    URL_HASH SHA256=c45f3e19c3eb71fc8b7210cb04cac658015fc1839e7cc0571f7406588ff9bcef
+    URL      https://github.com/kokkos/kokkos/releases/download/5.0.1/kokkos-5.0.1.tar.gz
+    URL_HASH SHA256=cf7d8515ca993229929be9f051aecd8f93cde325adac8a4f82ed6848adace218
 )
 FetchContent_MakeAvailable(Kokkos)
 

--- a/benchmarks/vector_ping_pong/CMakeLists.txt
+++ b/benchmarks/vector_ping_pong/CMakeLists.txt
@@ -4,8 +4,8 @@ project(vector_ping_pong CXX)
 include(FetchContent)
 FetchContent_Declare(
     Kokkos
-    URL      https://github.com/kokkos/kokkos/releases/download/4.7.01/kokkos-4.7.01.tar.gz
-    URL_HASH SHA256=404cf33e76159e83b8b4ad5d86f6899d442b5da4624820ab457412116cdcd201
+    URL      https://github.com/kokkos/kokkos/releases/download/5.0.0/kokkos-5.0.0.tar.gz
+    URL_HASH SHA256=c45f3e19c3eb71fc8b7210cb04cac658015fc1839e7cc0571f7406588ff9bcef
 )
 FetchContent_MakeAvailable(Kokkos)
 

--- a/benchmarks/vector_ping_pong/CMakeLists.txt
+++ b/benchmarks/vector_ping_pong/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+project(vector_ping_pong CXX)
+
+include(FetchContent)
+FetchContent_Declare(
+    Kokkos
+    URL      https://github.com/kokkos/kokkos/releases/download/4.7.01/kokkos-4.7.01.tar.gz
+    URL_HASH SHA256=404cf33e76159e83b8b4ad5d86f6899d442b5da4624820ab457412116cdcd201
+)
+FetchContent_MakeAvailable(Kokkos)
+
+add_executable(vector_ping_pong vector_ping_pong-kokkos.cpp)
+target_link_libraries(vector_ping_pong PRIVATE Kokkos::kokkos)

--- a/benchmarks/vector_ping_pong/run.bash
+++ b/benchmarks/vector_ping_pong/run.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+declare -a variations=("device-hostpinned" "device-new" "device-managed" "managed-none" "new-none" "malloc-none" "device-none")
+
+for warmups in 100
+do
+  for pingpongs in 100
+  do
+    for stride in 1 2 4 8 16 32
+    do
+      for size in 2**10 2**12 2**14 2**16 2**20 2**22
+      do
+         for variation in "${variations[@]}"
+         do
+            ./Kokkos_vector_ping_pong "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}"
+         done
+       done
+    done
+  done
+done

--- a/benchmarks/vector_ping_pong/run.bash
+++ b/benchmarks/vector_ping_pong/run.bash
@@ -4,17 +4,23 @@ declare -a variations=("device-hostpinned" "device-new" "device-managed" "manage
 
 for warmups in 100
 do
-  for pingpongs in 100
-  do
-    for stride in 1 2 4 8 16 32
+  for pingpongs in 1000
     do
-      for size in 2**8 2**10 2**12 2**14 2**16 2**18 2**20 2**22 2**24 2**26 2**28 2**30
+    for pings in 1 10 100 1000
       do
-         for variation in "${variations[@]}"
-         do
-            ./build/vector_ping_pong "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}"
-         done
-       done
+      for pongs in 1 10 100 1000
+        do
+        for stride in 1 2 4 8 16 32
+          do
+          for size in 2**8 2**10 2**12 2**14 2**16 2**18 2**20 2**22 2**24 2**26 2**28 2**30
+            do
+            for variation in "${variations[@]}"
+              do
+              ./build/vector_ping_pong "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}" "${pings}" "${pongs}"
+            done
+          done
+        done
+      done
     done
   done
 done

--- a/benchmarks/vector_ping_pong/run.bash
+++ b/benchmarks/vector_ping_pong/run.bash
@@ -19,7 +19,9 @@ do
             do
             for variation in "${variations[@]}"
               do
+              echo "running: ${prefix} $variation 10 $((size)) ${warmups} ${pingpongs} ${stride} ${pings} ${pongs}"
               ${executable} "${prefix}" "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}" "${pings}" "${pongs}"
+              echo "done: ${prefix} $variation 10 $((size)) ${warmups} ${pingpongs} ${stride} ${pings} ${pongs}"
             done
           done
         done
@@ -27,3 +29,4 @@ do
     done
   done
 done
+echo "FINISH ${prefix}"

--- a/benchmarks/vector_ping_pong/run.bash
+++ b/benchmarks/vector_ping_pong/run.bash
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+executable=$1
+prefix=$2
+
 declare -a variations=("device-hostpinned" "device-new" "device-managed" "managed-none" "new-none" "malloc-none" "device-none")
 
 for warmups in 100
@@ -16,7 +19,7 @@ do
             do
             for variation in "${variations[@]}"
               do
-              ./build/vector_ping_pong "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}" "${pings}" "${pongs}"
+              ${executable} "${prefix}" "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}" "${pings}" "${pongs}"
             done
           done
         done

--- a/benchmarks/vector_ping_pong/run.bash
+++ b/benchmarks/vector_ping_pong/run.bash
@@ -8,11 +8,11 @@ do
   do
     for stride in 1 2 4 8 16 32
     do
-      for size in 2**10 2**12 2**14 2**16 2**20 2**22
+      for size in 2**8 2**10 2**12 2**14 2**16 2**18 2**20 2**22 2**24 2**26 2**28 2**30
       do
          for variation in "${variations[@]}"
          do
-            ./Kokkos_vector_ping_pong "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}"
+            ./vector_ping_pong "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}"
          done
        done
     done

--- a/benchmarks/vector_ping_pong/run.bash
+++ b/benchmarks/vector_ping_pong/run.bash
@@ -12,7 +12,7 @@ do
       do
          for variation in "${variations[@]}"
          do
-            ./vector_ping_pong "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}"
+            ./build/vector_ping_pong "$variation" 10 "$((size))" "${warmups}" "${pingpongs}" "${stride}"
          done
        done
     done

--- a/benchmarks/vector_ping_pong/run_tests.sh
+++ b/benchmarks/vector_ping_pong/run_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+rm -rf build && cmake -B build -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build -j 10
+
+nohup ./run.bash &

--- a/benchmarks/vector_ping_pong/run_tests.sh
+++ b/benchmarks/vector_ping_pong/run_tests.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-rm -rf build && cmake -B build -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build -j 10
-
-nohup ./run.bash &

--- a/benchmarks/vector_ping_pong/run_tests_gh200.sh
+++ b/benchmarks/vector_ping_pong/run_tests_gh200.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+rm -rf build_gh200 && cmake -B build_gh200 -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_gh200 -j 10
+
+echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash &> run_gh200.out" | at 22:00
+echo "Queued GH200 job"

--- a/benchmarks/vector_ping_pong/run_tests_gh200.sh
+++ b/benchmarks/vector_ping_pong/run_tests_gh200.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 module load cmake/3.31.1 gcc/12.2.0 cuda/13.0
-rm -rf build_gh200 && cmake -B build_gh200 -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_gh200 -j 10
+rm -rf build_gh200
+cmake -B build_gh200 -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_gh200 -j 10
 
 echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash ./build_gh200/vector_ping_pong gh200 &> run_gh200.out" | at 22:00
 echo "Queued GH200 job"

--- a/benchmarks/vector_ping_pong/run_tests_gh200.sh
+++ b/benchmarks/vector_ping_pong/run_tests_gh200.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+module load cmake/3.31.1 gcc/12.2.0 cuda/13.0
 rm -rf build_gh200 && cmake -B build_gh200 -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_gh200 -j 10
 
 echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash ./build_gh200/vector_ping_pong gh200 &> run_gh200.out" | at 22:00

--- a/benchmarks/vector_ping_pong/run_tests_gh200.sh
+++ b/benchmarks/vector_ping_pong/run_tests_gh200.sh
@@ -2,5 +2,5 @@
 
 rm -rf build_gh200 && cmake -B build_gh200 -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_gh200 -j 10
 
-echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash &> run_gh200.out" | at 22:00
+echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash ./build_gh200/vector_ping_pong gh200 &> run_gh200.out" | at 22:00
 echo "Queued GH200 job"

--- a/benchmarks/vector_ping_pong/run_tests_h100.sh
+++ b/benchmarks/vector_ping_pong/run_tests_h100.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 module load cmake/3.31.1 gcc/12.2.0 cuda/13.0
-rm -rf build_h100 && cmake -B build_h100 -DCMAKE_CXX_COMPILER=g++ -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_h100 -j 10
+rm -rf build_h100
+cmake -B build_h100 -DCMAKE_CXX_COMPILER=g++ -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_h100 -j 10
 
 echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash ./build_h100/vector_ping_pong h100 &> run_h100.out" | at 22:00
 echo "Queued H100 job"

--- a/benchmarks/vector_ping_pong/run_tests_h100.sh
+++ b/benchmarks/vector_ping_pong/run_tests_h100.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-rm -rf build_h100 && cmake -B build_h100 -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_h100 -j 10
+module load cmake/3.31.1 gcc/12.2.0 cuda/13.0
+rm -rf build_h100 && cmake -B build_h100 -DCMAKE_CXX_COMPILER=g++ -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_h100 -j 10
 
 echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash ./build_h100/vector_ping_pong h100 &> run_h100.out" | at 22:00
 echo "Queued H100 job"

--- a/benchmarks/vector_ping_pong/run_tests_h100.sh
+++ b/benchmarks/vector_ping_pong/run_tests_h100.sh
@@ -2,5 +2,5 @@
 
 rm -rf build_h100 && cmake -B build_h100 -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_h100 -j 10
 
-echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash &> run_h100.out" | at 22:00
+echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash ./build_h100/vector_ping_pong h100 &> run_h100.out" | at 22:00
 echo "Queued H100 job"

--- a/benchmarks/vector_ping_pong/run_tests_h100.sh
+++ b/benchmarks/vector_ping_pong/run_tests_h100.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+rm -rf build_h100 && cmake -B build_h100 -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON && cmake --build build_h100 -j 10
+
+echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash &> run_h100.out" | at 22:00
+echo "Queued H100 job"

--- a/benchmarks/vector_ping_pong/run_tests_mi210.sh
+++ b/benchmarks/vector_ping_pong/run_tests_mi210.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+rm -rf build_mi210 && cmake -B build_mi210 -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX90A=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DCMAKE_CXX_COMPILER=hipcc && cmake --build build_mi210 -j 10
+
+echo "OMP_PROC_BIND=spread OMP_PLACES=threads HSA_XNACK=1 ./run.bash ./build_mi210/vector_ping_pong mi210 &> run_mi210.out" | at 22:00
+echo "Queued MI210 job"

--- a/benchmarks/vector_ping_pong/run_tests_mi210.sh
+++ b/benchmarks/vector_ping_pong/run_tests_mi210.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 module load rocm/6.4.0 cmake/3.31.1
-rm -rf build_mi210 && cmake -B build_mi210 -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX90A=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DCMAKE_CXX_COMPILER=hipcc && cmake --build build_mi210 -j 10
+rm -rf build_mi210
+cmake -B build_mi210 -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX90A=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DCMAKE_CXX_COMPILER=hipcc && cmake --build build_mi210 -j 10
 
 echo "OMP_PROC_BIND=spread OMP_PLACES=threads HSA_XNACK=1 ./run.bash ./build_mi210/vector_ping_pong mi210 &> run_mi210.out" | at 22:00
 echo "Queued MI210 job"

--- a/benchmarks/vector_ping_pong/run_tests_mi210.sh
+++ b/benchmarks/vector_ping_pong/run_tests_mi210.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+module load rocm/6.4.0 cmake/3.31.1
 rm -rf build_mi210 && cmake -B build_mi210 -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX90A=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DCMAKE_CXX_COMPILER=hipcc && cmake --build build_mi210 -j 10
 
 echo "OMP_PROC_BIND=spread OMP_PLACES=threads HSA_XNACK=1 ./run.bash ./build_mi210/vector_ping_pong mi210 &> run_mi210.out" | at 22:00

--- a/benchmarks/vector_ping_pong/run_tests_mi300a.sh
+++ b/benchmarks/vector_ping_pong/run_tests_mi300a.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 module load rocm/6.4.0 cmake/3.31.1
-rm -rf build_mi300a && cmake -B build_mi300a -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX942_APU=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DCMAKE_CXX_COMPILER=hipcc && cmake --build build_mi300a -j 10
+rm -rf build_mi300a
+cmake -B build_mi300a -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX942_APU=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DCMAKE_CXX_COMPILER=hipcc && cmake --build build_mi300a -j 10
 
 echo "OMP_PROC_BIND=spread OMP_PLACES=threads HSA_XNACK=1 ./run.bash ./build_mi300a/vector_ping_pong mi300a &> run_mi300a.out" | at 22:00
 echo "Queued MI300A job"

--- a/benchmarks/vector_ping_pong/run_tests_mi300a.sh
+++ b/benchmarks/vector_ping_pong/run_tests_mi300a.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
+module load rocm/6.4.0 cmake/3.31.1
 rm -rf build_mi300a && cmake -B build_mi300a -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX942_APU=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DCMAKE_CXX_COMPILER=hipcc && cmake --build build_mi300a -j 10
 
-echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash ./build_mi300a/vector_ping_pong mi300a &> run_mi300a.out" | at 22:00
+echo "OMP_PROC_BIND=spread OMP_PLACES=threads HSA_XNACK=1 ./run.bash ./build_mi300a/vector_ping_pong mi300a &> run_mi300a.out" | at 22:00
 echo "Queued MI300A job"

--- a/benchmarks/vector_ping_pong/run_tests_mi300a.sh
+++ b/benchmarks/vector_ping_pong/run_tests_mi300a.sh
@@ -2,5 +2,5 @@
 
 rm -rf build_mi300a && cmake -B build_mi300a -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX942_APU=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DCMAKE_CXX_COMPILER=hipcc && cmake --build build_mi300a -j 10
 
-echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash &> run_mi300a.out" | at 22:00
+echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash ./build_mi300a/vector_ping_pong mi300a &> run_mi300a.out" | at 22:00
 echo "Queued MI300A job"

--- a/benchmarks/vector_ping_pong/run_tests_mi300a.sh
+++ b/benchmarks/vector_ping_pong/run_tests_mi300a.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+rm -rf build_mi300a && cmake -B build_mi300a -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX942_APU=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DCMAKE_CXX_COMPILER=hipcc && cmake --build build_mi300a -j 10
+
+echo "OMP_PROC_BIND=spread OMP_PLACES=threads ./run.bash &> run_mi300a.out" | at 22:00
+echo "Queued MI300A job"

--- a/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
+++ b/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
@@ -284,23 +284,24 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
     using ValueType = int;
     using IndexType = unsigned int;
 
-    if (argc < 8)
+    if (argc < 9)
       printf(
-          "Arguments: mode repetitions array_size "
+          "Arguments: prefix mode repetitions array_size "
           "warmup_runs ping_pongs stride pings pongs/n");
 
-    const std::string mode(argv[1]);
-    int repetitions      = std::stoi(argv[2]);
-    IndexType array_size = std::stoi(argv[3]);
-    int warmup_runs      = std::stoi(argv[4]);
-    int ping_pongs       = std::stoi(argv[5]);
-    IndexType stride     = std::stoi(argv[6]);
-    int pings            = std::stoi(argv[7]);
-    int pongs            = std::stoi(argv[8]);
+    const std::string prefix(argv[1]);
+    const std::string mode(argv[2]);
+    int repetitions      = std::stoi(argv[3]);
+    IndexType array_size = std::stoi(argv[4]);
+    int warmup_runs      = std::stoi(argv[5]);
+    int ping_pongs       = std::stoi(argv[6]);
+    IndexType stride     = std::stoi(argv[7]);
+    int pings            = std::stoi(argv[8]);
+    int pongs            = std::stoi(argv[9]);
 
     std::ofstream outfile;
-    outfile.open(mode + "_" + argv[3] + "_" + argv[4] + "_" + argv[5] + "_" +
-                     argv[6] + "_" + argv[7] + "_" + argv[8] + ".csv",
+    outfile.open(prefix + mode + "_" + argv[3] + "_" + argv[4] + "_" + argv[5] +
+                     "_" + argv[6] + "_" + argv[7] + "_" + argv[8] + ".csv",
                  std::ios::out);
 
     Kokkos::print_configuration(outfile);

--- a/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
+++ b/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
@@ -22,6 +22,21 @@
 
 #include <sys/time.h>
 
+template <typename ViewType, typename VectorIndex>
+KOKKOS_INLINE_FUNCTION void workload(ViewType const& view,
+                                     const VectorIndex index, int num_ops) {
+  using ValueType = typename ViewType::value_type;
+
+  ValueType a1      = view(index);
+  const ValueType b = a1;
+
+  for (int f = 0; f < num_ops; f++) {
+    a1 += b * a1;
+  }
+
+  view(index) = a1;
+}
+
 template <typename MemorySpacePing, typename MemorySpacePong,
           typename ExecutionSpacePing, typename ExecutionSpacePong,
           typename ExecutionSpaceFirstTouchPing,
@@ -31,7 +46,14 @@ std::tuple<int, double> run_benchmark(VectorValue* ping_data,
                                       VectorValue* pong_data, VectorIndex size,
                                       int warmup_runs, int num_pingpongs,
                                       VectorIndex stride, int num_pings,
-                                      int num_pongs) {
+                                      int num_pongs, int scratch_size,
+                                      int num_teams, int num_repetions_per_team,
+                                      int num_ops) {
+  if (size % num_teams != 0) {
+    Kokkos::abort("Size of array must be a multiple of num_teams \n");
+  }
+  auto team_size = size / num_teams;
+
   auto warmup_view =
       Kokkos::View<VectorValue*, MemorySpacePing>{"warmup", size};
 
@@ -67,7 +89,7 @@ std::tuple<int, double> run_benchmark(VectorValue* ping_data,
         "first_touch_pong",
         Kokkos::RangePolicy(ExecutionSpaceFirstTouchPong(), 0, size),
         KOKKOS_LAMBDA(const VectorIndex idx) {
-          pong_view(idx) = VectorValue{};
+          pong_view(idx) = VectorValue{1.0};
         });
     Kokkos::fence();
   }
@@ -80,16 +102,38 @@ std::tuple<int, double> run_benchmark(VectorValue* ping_data,
       Kokkos::fence();
     for (auto j = 0; j < num_pings; ++j)
       Kokkos::parallel_for(
-          "ping", Kokkos::RangePolicy(ExecutionSpacePing(), 0, size),
-          KOKKOS_LAMBDA(const VectorIndex idx) { ++ping_view(idx); });
+          "ping",
+          Kokkos::TeamPolicy(ExecutionSpacePing(), num_teams, team_size)
+              .set_scratch_size(0, Kokkos::PerTeam(scratch_size)),
+          KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team) {
+            const VectorIndex n = team.league_rank() * (team.team_size());
+            for (int r = 0; r < num_repetions_per_team; r++) {
+              Kokkos::parallel_for(
+                  Kokkos::TeamThreadRange(team, n, n + team.team_size()),
+                  [&](const VectorIndex& i) {
+                    workload(ping_view, i, num_ops);
+                  });
+            }
+          });
     if constexpr (needs_deep_copy)
       Kokkos::deep_copy(pong_view, ping_view);
     else
       Kokkos::fence();
     for (auto j = 0; j < num_pings; ++j)
       Kokkos::parallel_for(
-          "pong", Kokkos::RangePolicy(ExecutionSpacePong(), 0, size),
-          KOKKOS_LAMBDA(const VectorIndex idx) { ++pong_view(idx); });
+          "pong",
+          Kokkos::TeamPolicy(ExecutionSpacePing(), num_teams, team_size)
+              .set_scratch_size(0, Kokkos::PerTeam(scratch_size)),
+          KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team) {
+            const VectorIndex n = team.league_rank() * (team.team_size());
+            for (int r = 0; r < num_repetions_per_team; r++) {
+              Kokkos::parallel_for(
+                  Kokkos::TeamThreadRange(team, n, n + team.team_size()),
+                  [&](const VectorIndex& i) {
+                    workload(pong_view, i, num_ops);
+                  });
+            }
+          });
   }
   Kokkos::fence();
   auto totalTime = timer.seconds();
@@ -211,7 +255,8 @@ template <typename ValueType, typename ExecutionSpacePing,
           typename AllocatorPong, typename IndexType>
 auto benchmark_views(IndexType size, int warmups, int pingpongs,
                      IndexType stride, AllocatorPing, AllocatorPong, int pings,
-                     int pongs) {
+                     int pongs, int scratch_size, int num_teams,
+                     int num_repetions_per_team, int num_ops) {
   ValueType* vec_ping =
       AllocatorPing::template allocate<ValueType>(size * stride);
   ValueType* vec_pong =
@@ -221,7 +266,8 @@ auto benchmark_views(IndexType size, int warmups, int pingpongs,
                           ExecutionSpacePing, ExecutionSpacePong,
                           ExecutionSpaceFirstTouchPing,
                           ExecutionSpaceFirstTouchPong, true>(
-      vec_ping, vec_pong, size, warmups, pingpongs, stride, pings, pongs);
+      vec_ping, vec_pong, size, warmups, pingpongs, stride, pings, pongs,
+      scratch_size, num_teams, num_repetions_per_team, num_ops);
 
   AllocatorPing::deallocate(vec_ping);
   AllocatorPong::deallocate(vec_pong);
@@ -235,16 +281,17 @@ template <typename ValueType, typename ExecutionSpacePing,
           typename IndexType>
 auto benchmark_views(IndexType size, int warmups, int pingpongs,
                      IndexType stride, AllocatorPingPong, NONE, int pings,
-                     int pongs) {
+                     int pongs, int scratch_size, int num_teams,
+                     int num_repetions_per_team, int num_ops) {
   ValueType* vec_ping_pong =
       AllocatorPingPong::template allocate<ValueType>(size * stride);
 
-  auto rc =
-      run_benchmark<Kokkos::SharedSpace, Kokkos::SharedSpace,
-                    ExecutionSpacePing, ExecutionSpacePong,
-                    ExecutionSpaceFirstTouchPing, ExecutionSpaceFirstTouchPong,
-                    false>(vec_ping_pong, vec_ping_pong, size, warmups,
-                           pingpongs, stride, pings, pongs);
+  auto rc = run_benchmark<Kokkos::SharedSpace, Kokkos::SharedSpace,
+                          ExecutionSpacePing, ExecutionSpacePong,
+                          ExecutionSpaceFirstTouchPing,
+                          ExecutionSpaceFirstTouchPong, false>(
+      vec_ping_pong, vec_ping_pong, size, warmups, pingpongs, stride, pings,
+      pongs, scratch_size, num_teams, num_repetions_per_team, num_ops);
 
   AllocatorPingPong::deallocate(vec_ping_pong);
 
@@ -257,12 +304,14 @@ void benchmark_and_print(std::ostream& out, unsigned const rep,
                          IndexType array_size, unsigned warmups,
                          unsigned pingpongs, IndexType stride,
                          AllocatorPing Aping, AllocatorPong Apong, int pings,
-                         int pongs) {
+                         int pongs, int scratch_size, int num_teams,
+                         int num_repetions_per_team, int num_ops) {
   auto [rc, timing] = benchmark_views<ValueType, Kokkos::DefaultExecutionSpace,
                                       Kokkos::DefaultHostExecutionSpace,
                                       Kokkos::DefaultExecutionSpace,
                                       Kokkos::DefaultHostExecutionSpace>(
-      array_size, warmups, pingpongs, stride, Aping, Apong, pings, pongs);
+      array_size, warmups, pingpongs, stride, Aping, Apong, pings, pongs,
+      scratch_size, num_teams, num_repetions_per_team, num_ops);
   if (rc != 0) {
     std::cout << "WRONG RESULT in rep " << rep << " array_size " << array_size
               << " warmups " << warmups << " pingpongs " << pingpongs
@@ -282,8 +331,8 @@ void benchmark_and_print(std::ostream& out, unsigned const rep,
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   Kokkos::initialize(argc, argv);
   {
-    using ValueType = int;
-    using IndexType = unsigned int;
+    using ValueType = double;
+    using IndexType = std::size_t;
 
     if (argc < 9)
       printf(
@@ -315,119 +364,150 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
                "pings, "
                "pongs "
             << std::endl;
+    // TODO get these values from the input and write to output. Also adapt the
+    // run scripts to do that.
+    int scratch_size, num_teams, num_repetions_per_team, num_ops;
+    // TODO
+    // revisit check of output ... if runs are repeated the check we currently
+    // run should give the wrong answer to compare against.
 
     for (int rep = 0; rep <= repetitions; ++rep) {
       // TWO VIEWS
       // MANAGED
       if (mode == "managed-managed")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, ManagedMalloc(),
-                                       ManagedMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            ManagedMalloc(), ManagedMalloc(), pings, pongs, scratch_size,
+            num_teams, num_repetions_per_team, num_ops);
       else if (mode == "managed-new")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, ManagedMalloc(),
-                                       StdNew(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            ManagedMalloc(), StdNew(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "managed-malloc")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, ManagedMalloc(),
-                                       StdMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            ManagedMalloc(), StdMalloc(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "managed-hostpinned")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, ManagedMalloc(),
-                                       HostPinnedMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            ManagedMalloc(), HostPinnedMalloc(), pings, pongs, scratch_size,
+            num_teams, num_repetions_per_team, num_ops);
       else if (mode == "managed-device")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, ManagedMalloc(),
-                                       DeviceMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            ManagedMalloc(), DeviceMalloc(), pings, pongs, scratch_size,
+            num_teams, num_repetions_per_team, num_ops);
 
       // DEVICE
       else if (mode == "device-managed")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       ManagedMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), ManagedMalloc(), pings, pongs, scratch_size,
+            num_teams, num_repetions_per_team, num_ops);
       else if (mode == "device-new")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       StdNew(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), StdNew(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "device-malloc")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       StdMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), StdMalloc(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "device-hostpinned")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       HostPinnedMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), HostPinnedMalloc(), pings, pongs, scratch_size,
+            num_teams, num_repetions_per_team, num_ops);
       else if (mode == "device-device")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       DeviceMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), DeviceMalloc(), pings, pongs, scratch_size,
+            num_teams, num_repetions_per_team, num_ops);
 
       // HostPinned
       else if (mode == "hostpinned-managed")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       ManagedMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), ManagedMalloc(), pings, pongs, scratch_size,
+            num_teams, num_repetions_per_team, num_ops);
       else if (mode == "hostpinned-new")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       StdNew(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), StdNew(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "hostpinned-malloc")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       StdMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), StdMalloc(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "hostpinned-hostpinned")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       HostPinnedMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), HostPinnedMalloc(), pings, pongs, scratch_size,
+            num_teams, num_repetions_per_team, num_ops);
       else if (mode == "hostpinned-device")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       DeviceMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), DeviceMalloc(), pings, pongs, scratch_size,
+            num_teams, num_repetions_per_team, num_ops);
 
       // NEW
       else if (mode == "new-managed")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, StdNew(),
-                                       ManagedMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride, StdNew(),
+            ManagedMalloc(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "new-new")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, StdNew(), StdNew(),
-                                       pings, pongs);
+                                       pings, pongs, scratch_size, num_teams,
+                                       num_repetions_per_team, num_ops);
       else if (mode == "new-malloc")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, StdNew(),
-                                       StdMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride, StdNew(),
+            StdMalloc(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "new-hostpinned")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, StdNew(),
-                                       HostPinnedMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride, StdNew(),
+            HostPinnedMalloc(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "new-device")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, StdNew(),
-                                       DeviceMalloc(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride, StdNew(),
+            DeviceMalloc(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
 
       // ONE VIEW
       // MANAGED
       else if (mode == "managed-none")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, ManagedMalloc(),
-                                       NONE(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            ManagedMalloc(), NONE(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "hostpinned-none")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, ManagedMalloc(),
-                                       NONE(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            ManagedMalloc(), NONE(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "device-none")
-        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, DeviceMalloc(),
-                                       NONE(), pings, pongs);
+        benchmark_and_print<ValueType>(
+            outfile, rep, array_size, warmup_runs, ping_pongs, stride,
+            DeviceMalloc(), NONE(), pings, pongs, scratch_size, num_teams,
+            num_repetions_per_team, num_ops);
       else if (mode == "malloc-none")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, StdMalloc(), NONE(),
-                                       pings, pongs);
+                                       pings, pongs, scratch_size, num_teams,
+                                       num_repetions_per_team, num_ops);
       else if (mode == "new-none")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, StdNew(), NONE(),
-                                       pings, pongs);
+                                       pings, pongs, scratch_size, num_teams,
+                                       num_repetions_per_team, num_ops);
     }
     outfile.close();
   }

--- a/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
+++ b/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
@@ -30,7 +30,8 @@ template <typename MemorySpacePing, typename MemorySpacePong,
 std::tuple<int, double> run_benchmark(VectorValue* ping_data,
                                       VectorValue* pong_data, VectorIndex size,
                                       int warmup_runs, int num_pingpongs,
-                                      VectorIndex stride) {
+                                      VectorIndex stride, int num_pings,
+                                      int num_pongs) {
   auto warmup_view =
       Kokkos::View<VectorValue*, MemorySpacePing>{"warmup", size};
 
@@ -77,16 +78,18 @@ std::tuple<int, double> run_benchmark(VectorValue* ping_data,
       Kokkos::deep_copy(ping_view, pong_view);
     else
       Kokkos::fence();
-    Kokkos::parallel_for(
-        "ping", Kokkos::RangePolicy(ExecutionSpacePing(), 0, size),
-        KOKKOS_LAMBDA(const VectorIndex idx) { ++ping_view(idx); });
+    for (auto j = 0; j < num_pings; ++j)
+      Kokkos::parallel_for(
+          "ping", Kokkos::RangePolicy(ExecutionSpacePing(), 0, size),
+          KOKKOS_LAMBDA(const VectorIndex idx) { ++ping_view(idx); });
     if constexpr (needs_deep_copy)
       Kokkos::deep_copy(pong_view, ping_view);
     else
       Kokkos::fence();
-    Kokkos::parallel_for(
-        "pong", Kokkos::RangePolicy(ExecutionSpacePong(), 0, size),
-        KOKKOS_LAMBDA(const VectorIndex idx) { ++pong_view(idx); });
+    for (auto j = 0; j < num_pings; ++j)
+      Kokkos::parallel_for(
+          "pong", Kokkos::RangePolicy(ExecutionSpacePong(), 0, size),
+          KOKKOS_LAMBDA(const VectorIndex idx) { ++pong_view(idx); });
   }
   Kokkos::fence();
   auto totalTime = timer.seconds();
@@ -98,7 +101,8 @@ std::tuple<int, double> run_benchmark(VectorValue* ping_data,
   Kokkos::parallel_reduce(
       "error_check", Kokkos::RangePolicy(ExecutionSpacePing(), 0, size),
       KOKKOS_LAMBDA(const VectorIndex i, int& error) {
-        error += (ping_view(i) == static_cast<VectorValue>(num_pingpongs) * 2)
+        error += (ping_view(i) == static_cast<VectorValue>(num_pingpongs) *
+                                      (num_pings + num_pongs))
                      ? 0
                      : 1;
       },
@@ -206,17 +210,18 @@ template <typename ValueType, typename ExecutionSpacePing,
           typename ExecutionSpaceFirstTouchPong, typename AllocatorPing,
           typename AllocatorPong, typename IndexType>
 auto benchmark_views(IndexType size, int warmups, int pingpongs,
-                     IndexType stride, AllocatorPing, AllocatorPong) {
+                     IndexType stride, AllocatorPing, AllocatorPong, int pings,
+                     int pongs) {
   ValueType* vec_ping =
       AllocatorPing::template allocate<ValueType>(size * stride);
   ValueType* vec_pong =
       AllocatorPong::template allocate<ValueType>(size * stride);
 
-  auto rc =
-      run_benchmark<Kokkos::SharedSpace, Kokkos::SharedSpace,
-                    ExecutionSpacePing, ExecutionSpacePong,
-                    ExecutionSpaceFirstTouchPing, ExecutionSpaceFirstTouchPong,
-                    true>(vec_ping, vec_pong, size, warmups, pingpongs, stride);
+  auto rc = run_benchmark<Kokkos::SharedSpace, Kokkos::SharedSpace,
+                          ExecutionSpacePing, ExecutionSpacePong,
+                          ExecutionSpaceFirstTouchPing,
+                          ExecutionSpaceFirstTouchPong, true>(
+      vec_ping, vec_pong, size, warmups, pingpongs, stride, pings, pongs);
 
   AllocatorPing::deallocate(vec_ping);
   AllocatorPong::deallocate(vec_pong);
@@ -229,15 +234,17 @@ template <typename ValueType, typename ExecutionSpacePing,
           typename ExecutionSpaceFirstTouchPong, typename AllocatorPingPong,
           typename IndexType>
 auto benchmark_views(IndexType size, int warmups, int pingpongs,
-                     IndexType stride, AllocatorPingPong, NONE) {
+                     IndexType stride, AllocatorPingPong, NONE, int pings,
+                     int pongs) {
   ValueType* vec_ping_pong =
       AllocatorPingPong::template allocate<ValueType>(size * stride);
 
-  auto rc = run_benchmark<Kokkos::SharedSpace, Kokkos::SharedSpace,
-                          ExecutionSpacePing, ExecutionSpacePong,
-                          ExecutionSpaceFirstTouchPing,
-                          ExecutionSpaceFirstTouchPong, false>(
-      vec_ping_pong, vec_ping_pong, size, warmups, pingpongs, stride);
+  auto rc =
+      run_benchmark<Kokkos::SharedSpace, Kokkos::SharedSpace,
+                    ExecutionSpacePing, ExecutionSpacePong,
+                    ExecutionSpaceFirstTouchPing, ExecutionSpaceFirstTouchPong,
+                    false>(vec_ping_pong, vec_ping_pong, size, warmups,
+                           pingpongs, stride, pings, pongs);
 
   AllocatorPingPong::deallocate(vec_ping_pong);
 
@@ -249,12 +256,13 @@ template <typename ValueType, typename IndexType, typename AllocatorPing,
 void benchmark_and_print(std::ostream& out, unsigned const rep,
                          IndexType array_size, unsigned warmups,
                          unsigned pingpongs, IndexType stride,
-                         AllocatorPing Aping, AllocatorPong Apong) {
+                         AllocatorPing Aping, AllocatorPong Apong, int pings,
+                         int pongs) {
   auto [rc, timing] = benchmark_views<ValueType, Kokkos::DefaultExecutionSpace,
                                       Kokkos::DefaultHostExecutionSpace,
                                       Kokkos::DefaultExecutionSpace,
                                       Kokkos::DefaultHostExecutionSpace>(
-      array_size, warmups, pingpongs, stride, Aping, Apong);
+      array_size, warmups, pingpongs, stride, Aping, Apong, pings, pongs);
   if (rc != 0) {
     std::cout << "WRONG RESULT in rep " << rep << " array_size " << array_size
               << " warmups " << warmups << " pingpongs " << pingpongs
@@ -276,10 +284,10 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
     using ValueType = int;
     using IndexType = unsigned int;
 
-    if (argc < 6)
+    if (argc < 8)
       printf(
           "Arguments: mode repetitions array_size "
-          "warmup_runs ping_pongs stride/n");
+          "warmup_runs ping_pongs stride pings pongs/n");
 
     const std::string mode(argv[1]);
     int repetitions      = std::stoi(argv[2]);
@@ -287,10 +295,12 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
     int warmup_runs      = std::stoi(argv[4]);
     int ping_pongs       = std::stoi(argv[5]);
     IndexType stride     = std::stoi(argv[6]);
+    int pings            = std::stoi(argv[7]);
+    int pongs            = std::stoi(argv[8]);
 
     std::ofstream outfile;
     outfile.open(mode + "_" + argv[3] + "_" + argv[4] + "_" + argv[5] + "_" +
-                     argv[6] + ".csv",
+                     argv[6] + "_" + argv[7] + "_" + argv[8] + ".csv",
                  std::ios::out);
 
     Kokkos::print_configuration(outfile);
@@ -307,109 +317,112 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
       if (mode == "managed-managed")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, ManagedMalloc(),
-                                       ManagedMalloc());
+                                       ManagedMalloc(), pings, pongs);
       else if (mode == "managed-new")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, ManagedMalloc(),
-                                       StdNew());
+                                       StdNew(), pings, pongs);
       else if (mode == "managed-malloc")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, ManagedMalloc(),
-                                       StdMalloc());
+                                       StdMalloc(), pings, pongs);
       else if (mode == "managed-hostpinned")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, ManagedMalloc(),
-                                       HostPinnedMalloc());
+                                       HostPinnedMalloc(), pings, pongs);
       else if (mode == "managed-device")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, ManagedMalloc(),
-                                       DeviceMalloc());
+                                       DeviceMalloc(), pings, pongs);
 
       // DEVICE
       else if (mode == "device-managed")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       ManagedMalloc());
+                                       ManagedMalloc(), pings, pongs);
       else if (mode == "device-new")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       StdNew());
+                                       StdNew(), pings, pongs);
       else if (mode == "device-malloc")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       StdMalloc());
+                                       StdMalloc(), pings, pongs);
       else if (mode == "device-hostpinned")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       HostPinnedMalloc());
+                                       HostPinnedMalloc(), pings, pongs);
       else if (mode == "device-device")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       DeviceMalloc());
+                                       DeviceMalloc(), pings, pongs);
 
       // HostPinned
       else if (mode == "hostpinned-managed")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       ManagedMalloc());
+                                       ManagedMalloc(), pings, pongs);
       else if (mode == "hostpinned-new")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       StdNew());
+                                       StdNew(), pings, pongs);
       else if (mode == "hostpinned-malloc")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       StdMalloc());
+                                       StdMalloc(), pings, pongs);
       else if (mode == "hostpinned-hostpinned")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       HostPinnedMalloc());
+                                       HostPinnedMalloc(), pings, pongs);
       else if (mode == "hostpinned-device")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       DeviceMalloc());
+                                       DeviceMalloc(), pings, pongs);
 
       // NEW
       else if (mode == "new-managed")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, StdNew(),
-                                       ManagedMalloc());
+                                       ManagedMalloc(), pings, pongs);
       else if (mode == "new-new")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, StdNew(), StdNew());
+                                       ping_pongs, stride, StdNew(), StdNew(),
+                                       pings, pongs);
       else if (mode == "new-malloc")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, StdNew(),
-                                       StdMalloc());
+                                       StdMalloc(), pings, pongs);
       else if (mode == "new-hostpinned")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, StdNew(),
-                                       HostPinnedMalloc());
+                                       HostPinnedMalloc(), pings, pongs);
       else if (mode == "new-device")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, StdNew(),
-                                       DeviceMalloc());
+                                       DeviceMalloc(), pings, pongs);
 
       // ONE VIEW
       // MANAGED
       else if (mode == "managed-none")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, ManagedMalloc(),
-                                       NONE());
+                                       NONE(), pings, pongs);
       else if (mode == "hostpinned-none")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, ManagedMalloc(),
-                                       NONE());
+                                       NONE(), pings, pongs);
       else if (mode == "device-none")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
                                        ping_pongs, stride, DeviceMalloc(),
-                                       NONE());
+                                       NONE(), pings, pongs);
       else if (mode == "malloc-none")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, StdMalloc(), NONE());
+                                       ping_pongs, stride, StdMalloc(), NONE(),
+                                       pings, pongs);
       else if (mode == "new-none")
         benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
-                                       ping_pongs, stride, StdNew(), NONE());
+                                       ping_pongs, stride, StdNew(), NONE(),
+                                       pings, pongs);
     }
     outfile.close();
   }

--- a/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
+++ b/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
@@ -1,0 +1,419 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Macros.hpp"
+
+#include <iostream>
+#include <fstream>
+
+#include <sys/time.h>
+
+template <typename MemorySpacePing, typename MemorySpacePong,
+          typename ExecutionSpacePing, typename ExecutionSpacePong,
+          typename ExecutionSpaceFirstTouchPing,
+          typename ExecutionSpaceFirstTouchPong, bool needs_deep_copy,
+          typename VectorValue, typename VectorIndex>
+std::tuple<int, double> run_benchmark(VectorValue* ping_data,
+                                      VectorValue* pong_data, VectorIndex size,
+                                      int warmup_runs, int num_pingpongs,
+                                      VectorIndex stride) {
+  auto warmup_view =
+      Kokkos::View<VectorValue*, MemorySpacePing>{"warmup", size};
+
+  Kokkos::LayoutStride layout_stride(size, stride);
+  auto ping_view =
+      Kokkos::View<VectorValue*, Kokkos::LayoutStride, MemorySpacePing>{
+          ping_data, layout_stride};
+  auto pong_view =
+      Kokkos::View<VectorValue*, Kokkos::LayoutStride, MemorySpacePong>{
+          pong_data, layout_stride};
+
+  // do warmup with another view so we don't mess up the placement
+  for (auto i = 0; i < warmup_runs; ++i) {
+    Kokkos::parallel_for(
+        "warmup inc", Kokkos::RangePolicy(ExecutionSpacePing(), 0, size),
+        KOKKOS_LAMBDA(const VectorIndex idx) { ++warmup_view(idx); });
+    Kokkos::parallel_for(
+        "warmup dec", Kokkos::RangePolicy(ExecutionSpacePing(), 0, size),
+        KOKKOS_LAMBDA(const VectorIndex idx) { --warmup_view(idx); });
+  }
+  Kokkos::fence();
+
+  Kokkos::parallel_for(
+      "first_touch_ping",
+      Kokkos::RangePolicy(ExecutionSpaceFirstTouchPing(), 0, size),
+      KOKKOS_LAMBDA(const VectorIndex idx) { ping_view(idx) = VectorValue{}; });
+  Kokkos::fence();
+
+  // if it needs a deepcopy there are two arrays, thus it also needs a pong
+  // first touch
+  if constexpr (needs_deep_copy) {
+    Kokkos::parallel_for(
+        "first_touch_pong",
+        Kokkos::RangePolicy(ExecutionSpaceFirstTouchPong(), 0, size),
+        KOKKOS_LAMBDA(const VectorIndex idx) {
+          pong_view(idx) = VectorValue{};
+        });
+    Kokkos::fence();
+  }
+
+  Kokkos::Timer timer;
+  for (auto i = 0; i < num_pingpongs; ++i) {
+    if constexpr (needs_deep_copy)
+      Kokkos::deep_copy(ping_view, pong_view);
+    else
+      Kokkos::fence();
+    Kokkos::parallel_for(
+        "ping", Kokkos::RangePolicy(ExecutionSpacePing(), 0, size),
+        KOKKOS_LAMBDA(const VectorIndex idx) { ++ping_view(idx); });
+    if constexpr (needs_deep_copy)
+      Kokkos::deep_copy(pong_view, ping_view);
+    else
+      Kokkos::fence();
+    Kokkos::parallel_for(
+        "pong", Kokkos::RangePolicy(ExecutionSpacePong(), 0, size),
+        KOKKOS_LAMBDA(const VectorIndex idx) { ++pong_view(idx); });
+  }
+  Kokkos::fence();
+  auto totalTime = timer.seconds();
+
+  // check for errors
+  int error_count = 0;
+  // since we ended on pong but want to check ping, we need to copy it again.
+  Kokkos::deep_copy(ping_view, pong_view);
+  Kokkos::parallel_reduce(
+      "error_check", Kokkos::RangePolicy(ExecutionSpacePing(), 0, size),
+      KOKKOS_LAMBDA(const VectorIndex i, int& error) {
+        error += (ping_view(i) == static_cast<VectorValue>(num_pingpongs) * 2)
+                     ? 0
+                     : 1;
+      },
+      error_count);
+  Kokkos::fence();
+  return std::make_tuple(error_count, totalTime);
+}
+
+//// ALLOCATOR DEALLOCATOR
+struct ManagedMalloc {
+  template <typename T>
+  static constexpr T* allocate(size_t size) {
+    T* ptr;
+#ifdef KOKKOS_ENABLE_CUDA
+    cudaMallocManaged(&ptr, size * sizeof(T));
+#elif defined KOKKOS_ENABLE_HIP
+    hipMallocManaged(&ptr, size * sizeof(T));
+#endif
+    return ptr;
+  }
+
+  template <typename T>
+  static constexpr void deallocate(T* ptr) {
+#ifdef KOKKOS_ENABLE_CUDA
+    cudaFree(ptr);
+#elif defined KOKKOS_ENABLE_HIP
+    hipFree(ptr);
+#endif
+  }
+};
+
+struct HostPinnedMalloc {
+  template <typename T>
+  static constexpr T* allocate(size_t size) {
+    T* ptr;
+#ifdef KOKKOS_ENABLE_CUDA
+    cudaMallocHost(&ptr, size * sizeof(T));
+#elif defined KOKKOS_ENABLE_HIP
+    hipHostMalloc(&ptr, size * sizeof(T));
+#endif
+    return ptr;
+  }
+
+  template <typename T>
+  static constexpr void deallocate(T* ptr) {
+#ifdef KOKKOS_ENABLE_CUDA
+    cudaFree(ptr);
+#elif defined KOKKOS_ENABLE_HIP
+    hipFree(ptr);
+#endif
+  }
+};
+
+struct DeviceMalloc {
+  template <typename T>
+  static constexpr T* allocate(size_t size) {
+    T* ptr;
+#ifdef KOKKOS_ENABLE_CUDA
+    cudaMalloc(&ptr, size * sizeof(T));
+#elif defined KOKKOS_ENABLE_HIP
+    hipMalloc(&ptr, size * sizeof(T));
+#endif
+    return ptr;
+  }
+
+  template <typename T>
+  static constexpr void deallocate(T* ptr) {
+#ifdef KOKKOS_ENABLE_CUDA
+    cudaFree(ptr);
+#elif defined KOKKOS_ENABLE_HIP
+    hipFree(ptr);
+#endif
+  }
+};
+
+struct StdMalloc {
+  template <typename T>
+  static constexpr T* allocate(size_t size) {
+    return static_cast<T*>(std::malloc(size * sizeof(T)));
+  }
+
+  template <typename T>
+  static constexpr void deallocate(T* ptr) {
+    std::free(ptr);
+  }
+};
+
+struct StdNew {
+  template <typename T>
+  static constexpr T* allocate(size_t size) {
+    return new T[size];
+  }
+
+  template <typename T>
+  static constexpr void deallocate(T* ptr) {
+    delete[] ptr;
+  }
+};
+
+struct NONE {};
+
+///////////////////////single and double array
+template <typename ValueType, typename ExecutionSpacePing,
+          typename ExecutionSpacePong, typename ExecutionSpaceFirstTouchPing,
+          typename ExecutionSpaceFirstTouchPong, typename AllocatorPing,
+          typename AllocatorPong, typename IndexType>
+auto benchmark_views(IndexType size, int warmups, int pingpongs,
+                     IndexType stride, AllocatorPing, AllocatorPong) {
+  ValueType* vec_ping =
+      AllocatorPing::template allocate<ValueType>(size * stride);
+  ValueType* vec_pong =
+      AllocatorPong::template allocate<ValueType>(size * stride);
+
+  auto rc =
+      run_benchmark<Kokkos::SharedSpace, Kokkos::SharedSpace,
+                    ExecutionSpacePing, ExecutionSpacePong,
+                    ExecutionSpaceFirstTouchPing, ExecutionSpaceFirstTouchPong,
+                    true>(vec_ping, vec_pong, size, warmups, pingpongs, stride);
+
+  AllocatorPing::deallocate(vec_ping);
+  AllocatorPong::deallocate(vec_pong);
+
+  return rc;
+}
+
+template <typename ValueType, typename ExecutionSpacePing,
+          typename ExecutionSpacePong, typename ExecutionSpaceFirstTouchPing,
+          typename ExecutionSpaceFirstTouchPong, typename AllocatorPingPong,
+          typename IndexType>
+auto benchmark_views(IndexType size, int warmups, int pingpongs,
+                     IndexType stride, AllocatorPingPong, NONE) {
+  ValueType* vec_ping_pong =
+      AllocatorPingPong::template allocate<ValueType>(size * stride);
+
+  auto rc = run_benchmark<Kokkos::SharedSpace, Kokkos::SharedSpace,
+                          ExecutionSpacePing, ExecutionSpacePong,
+                          ExecutionSpaceFirstTouchPing,
+                          ExecutionSpaceFirstTouchPong, false>(
+      vec_ping_pong, vec_ping_pong, size, warmups, pingpongs, stride);
+
+  AllocatorPingPong::deallocate(vec_ping_pong);
+
+  return rc;
+}
+
+template <typename ValueType, typename IndexType, typename AllocatorPing,
+          typename AllocatorPong = NONE>
+void benchmark_and_print(std::ostream& out, unsigned const rep,
+                         IndexType array_size, unsigned warmups,
+                         unsigned pingpongs, IndexType stride,
+                         AllocatorPing Aping, AllocatorPong Apong) {
+  auto [rc, timing] = benchmark_views<ValueType, Kokkos::DefaultExecutionSpace,
+                                      Kokkos::DefaultHostExecutionSpace,
+                                      Kokkos::DefaultExecutionSpace,
+                                      Kokkos::DefaultHostExecutionSpace>(
+      array_size, warmups, pingpongs, stride, Aping, Apong);
+  if (rc != 0) {
+    std::cout << "WRONG RESULT in rep " << rep << " array_size " << array_size
+              << " warmups " << warmups << " pingpongs " << pingpongs
+              << " stride " << stride << ".  exiting!" << std::endl;
+    std::exit(rc);
+  }
+
+  double bw = 1.0e-6 * 2.0 * pingpongs * array_size *
+              (double)sizeof(ValueType) / timing;
+  out << rep << " , " << array_size << " , " << warmups << " , " << pingpongs
+      << " , " << stride << " , " << bw << " , "
+      << typeid(AllocatorPing()).name() << " , "
+      << typeid(AllocatorPong()).name() << "\n";
+}
+
+int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+  Kokkos::initialize(argc, argv);
+  {
+    using ValueType = int;
+    using IndexType = unsigned int;
+
+    if (argc < 6)
+      printf(
+          "Arguments: mode repetitions array_size "
+          "warmup_runs ping_pongs stride/n");
+
+    const std::string mode(argv[1]);
+    int repetitions      = std::stoi(argv[2]);
+    IndexType array_size = std::stoi(argv[3]);
+    int warmup_runs      = std::stoi(argv[4]);
+    int ping_pongs       = std::stoi(argv[5]);
+    IndexType stride     = std::stoi(argv[6]);
+
+    std::ofstream outfile;
+    outfile.open(mode + "_" + argv[3] + "_" + argv[4] + "_" + argv[5] + "_" +
+                     argv[6] + ".csv",
+                 std::ios::out);
+
+    Kokkos::print_configuration(outfile);
+
+    outfile
+        << "# repetition, arraysize, warmups, pingpongs, stride, bandwidth, "
+           "allocatorPing, "
+           "allocatorPong"
+        << std::endl;
+
+    for (int rep = 0; rep <= repetitions; ++rep) {
+      // TWO VIEWS
+      // MANAGED
+      if (mode == "managed-managed")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, ManagedMalloc(),
+                                       ManagedMalloc());
+      else if (mode == "managed-new")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, ManagedMalloc(),
+                                       StdNew());
+      else if (mode == "managed-malloc")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, ManagedMalloc(),
+                                       StdMalloc());
+      else if (mode == "managed-hostpinned")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, ManagedMalloc(),
+                                       HostPinnedMalloc());
+      else if (mode == "managed-device")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, ManagedMalloc(),
+                                       DeviceMalloc());
+
+      // DEVICE
+      else if (mode == "device-managed")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       ManagedMalloc());
+      else if (mode == "device-new")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       StdNew());
+      else if (mode == "device-malloc")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       StdMalloc());
+      else if (mode == "device-hostpinned")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       HostPinnedMalloc());
+      else if (mode == "device-device")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       DeviceMalloc());
+
+      // HostPinned
+      else if (mode == "hostpinned-managed")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       ManagedMalloc());
+      else if (mode == "hostpinned-new")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       StdNew());
+      else if (mode == "hostpinned-malloc")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       StdMalloc());
+      else if (mode == "hostpinned-hostpinned")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       HostPinnedMalloc());
+      else if (mode == "hostpinned-device")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       DeviceMalloc());
+
+      // NEW
+      else if (mode == "new-managed")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, StdNew(),
+                                       ManagedMalloc());
+      else if (mode == "new-new")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, StdNew(), StdNew());
+      else if (mode == "new-malloc")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, StdNew(),
+                                       StdMalloc());
+      else if (mode == "new-hostpinned")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, StdNew(),
+                                       HostPinnedMalloc());
+      else if (mode == "new-device")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, StdNew(),
+                                       DeviceMalloc());
+
+      // ONE VIEW
+      // MANAGED
+      else if (mode == "managed-none")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, ManagedMalloc(),
+                                       NONE());
+      else if (mode == "hostpinned-none")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, ManagedMalloc(),
+                                       NONE());
+      else if (mode == "device-none")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, DeviceMalloc(),
+                                       NONE());
+      else if (mode == "malloc-none")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, StdMalloc(), NONE());
+      else if (mode == "new-none")
+        benchmark_and_print<ValueType>(outfile, rep, array_size, warmup_runs,
+                                       ping_pongs, stride, StdNew(), NONE());
+    }
+    outfile.close();
+  }
+  Kokkos::finalize();
+
+  return 0;
+}

--- a/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
+++ b/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
@@ -265,7 +265,7 @@ void benchmark_and_print(std::ostream& out, unsigned const rep,
   double bw = 1.0e-6 * 2.0 * pingpongs * array_size *
               (double)sizeof(ValueType) / timing;
   out << rep << " , " << array_size << " , " << warmups << " , " << pingpongs
-      << " , " << stride << " , " << bw << " , "
+      << " , " << stride << " , " << bw << " , " << timing << " , "
       << typeid(AllocatorPing()).name() << " , "
       << typeid(AllocatorPong()).name() << "\n";
 }
@@ -295,11 +295,11 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
 
     Kokkos::print_configuration(outfile);
 
-    outfile
-        << "# repetition, arraysize, warmups, pingpongs, stride, bandwidth, "
-           "allocatorPing, "
-           "allocatorPong"
-        << std::endl;
+    outfile << "# repetition, arraysize, warmups, pingpongs, stride, "
+               "bandwidth, time, "
+               "allocatorPing, "
+               "allocatorPong"
+            << std::endl;
 
     for (int rep = 0; rep <= repetitions; ++rep) {
       // TWO VIEWS

--- a/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
+++ b/benchmarks/vector_ping_pong/vector_ping_pong-kokkos.cpp
@@ -275,7 +275,8 @@ void benchmark_and_print(std::ostream& out, unsigned const rep,
   out << rep << " , " << array_size << " , " << warmups << " , " << pingpongs
       << " , " << stride << " , " << bw << " , " << timing << " , "
       << typeid(AllocatorPing()).name() << " , "
-      << typeid(AllocatorPong()).name() << "\n";
+      << typeid(AllocatorPong()).name() << " , " << pings << " , " << pongs
+      << "\n";
 }
 
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
@@ -300,8 +301,9 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
     int pongs            = std::stoi(argv[9]);
 
     std::ofstream outfile;
-    outfile.open(prefix + mode + "_" + argv[3] + "_" + argv[4] + "_" + argv[5] +
-                     "_" + argv[6] + "_" + argv[7] + "_" + argv[8] + ".csv",
+    outfile.open(prefix + "_" + mode + "_" + argv[3] + "_" + argv[4] + "_" +
+                     argv[5] + "_" + argv[6] + "_" + argv[7] + "_" + argv[8] +
+                     "_" + argv[9] + ".csv",
                  std::ios::out);
 
     Kokkos::print_configuration(outfile);
@@ -309,7 +311,9 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
     outfile << "# repetition, arraysize, warmups, pingpongs, stride, "
                "bandwidth, time, "
                "allocatorPing, "
-               "allocatorPong"
+               "allocatorPong, "
+               "pings, "
+               "pongs "
             << std::endl;
 
     for (int rep = 0; rep <= repetitions; ++rep) {

--- a/papers/hmm_paper/.latexmkrc
+++ b/papers/hmm_paper/.latexmkrc
@@ -1,0 +1,4 @@
+$pdf_mode = 1;
+$pdflatex = 'pdflatex -synctex=1 -interaction=nonstopmode -shell-escape';
+@generated_exts = (@generated_exts, 'synctex.gz');
+@default_files = ('main.tex');

--- a/papers/hmm_paper/main.tex
+++ b/papers/hmm_paper/main.tex
@@ -1,0 +1,32 @@
+\documentclass[a4paper,10pt]{scrartcl}
+
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+\usepackage{amsmath}
+\usepackage{hyperref}
+\usepackage{import}
+
+\usepackage{subfig}
+\usepackage{graphicx}
+\usepackage{pgfplots}
+\pgfplotsset{compat=1.18}
+\usepackage{pgfplotstable}
+\tikzset{>=stealth}
+\usetikzlibrary{patterns}
+\usetikzlibrary{pgfplots.statistics}
+\usepgfplotslibrary{external}
+\tikzexternalize
+\tikzsetexternalprefix{plots/}
+%\tikzset{external/force remake}
+
+\title{Influence of the Heterogenious Memory Management System on Kokkos Semantics }
+
+\author{Jakob Bludau}
+
+
+\begin{document}
+\maketitle
+
+\import{./src_plots/}{vector_ping_pong_gh200.tex}
+
+\end{document}

--- a/papers/hmm_paper/main.tex
+++ b/papers/hmm_paper/main.tex
@@ -160,13 +160,94 @@
 }
 
 \section{Kokkos' Memory Management Interface}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item Different versions of memory and which memory is accessible where. Which memory needs to be explicitly copied
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item How do the previously mentioned memory managemnt methods translate to Kokkos functions.
+\item Explain that deep\_copy etc can just become a no-op based on what the spaces and accessibility traits are.
+\item State that we prefer users to spell out the necessary memory transfers due to the reason mentioned above.
+\end{itemize}
+}
 
+\section{Vector ping-pong as proxy for scientific codes}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item What a vector is
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item Vector as continuous memory that can be copied or moved to another compute resource.
+\item Basic algorithm is repeated access on the device and the host
+\item Number of consecutive accesses on the same resource can be set. This allows to set how often transfers between host and device happen during execution.
+\item Number of floatingpoint operations per memory operation can be varied. This allows to traverse the space of memory-bound to compute-bound freely.
+\item Stride of the individual accesses can be set. This allows to control how much of a loaded cacheline can be used
+\end{itemize}
+}
 
+\section{Benchmark settings}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item What the vector ping pong is and what are parameters that can be set.
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item metric for individual kernel's memory bandwidth as function of flops,stride
+\item metric for completing a cycle (this will need to be defined)
+\end{itemize}
+}
 
-\section{GH200}
+\section{Benchmark results}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item What does which metric say
+\item What are the configurations
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item individual kernel's memory bandwidth as function of flops,stride and memory mechanism.
+\item performance for completing a cycle (this will need to be defined) as function of flops, stride and memory mechanism.
+\end{itemize}
+}
+
+\subsection{GH200}
 \import{./src_plots/}{vector_ping_pong_gh200.tex}
 
-\section{MI300A}
+\subsection{MI300A}
 \import{./src_plots/}{vector_ping_pong_mi300a.tex}
+
+\section{Discussion}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item What does which metric say
+\item What are the configurations
+\item What are the benchmark results
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item Comparison of the bandwidth of individual kernels vs the whole program
+\item Comparison which memory management method is good in which regime of the benchmark (size, flops, stride, architecture)
+\end{itemize}
+}
+
+\section{Conclusion}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item The rest of the paper
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item maybe that there is different memory management preferences for different architectures
+\item that explicitly specifying memory transfers is the most general solution, as these can easily be converted to no-ops if another method is faster.
+\end{itemize}
+}
 
 \end{document}

--- a/papers/hmm_paper/main.tex
+++ b/papers/hmm_paper/main.tex
@@ -41,6 +41,10 @@
 \begin{document}
 \maketitle
 
+\section{GH200}
 \import{./src_plots/}{vector_ping_pong_gh200.tex}
+
+\section{MI300A}
+\import{./src_plots/}{vector_ping_pong_mi300a.tex}
 
 \end{document}

--- a/papers/hmm_paper/main.tex
+++ b/papers/hmm_paper/main.tex
@@ -32,6 +32,8 @@
 \definecolor{KKPurple}{RGB}{99,41,199}
 \definecolor{KKDarkPurple}{RGB}{25,23,123}
 
+%%%%%%%%%%%%%%%%%%%%%% NOTES in red
+\newcommand\gist[1]{\textcolor{red}{#1}}
 
 \title{Influence of the Heterogenious Memory Management System on Kokkos Semantics }
 
@@ -40,6 +42,126 @@
 
 \begin{document}
 \maketitle
+
+\section{Introduction}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item Knowledge about Heterogenious computing being a thing
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item Performance benefits from heterogeneous computing
+\item most HPC machines heterogeneous
+\item Heterogenious computing uses multiple, disjunct compute resources
+\item Heterogenious computing uses (potentially) different hardware locations for memory
+\item For successful execution the compute resource has to have access to the memory
+\end{itemize}
+}
+
+\section{Memory Management in Heterogenious Architectures}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item Knowledge about Heterogenious computing and that memory needs to be accessible by the compute resource.
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item Various methods for giving the compute resource access to the memory it is working on
+\item How memory in different physical spaces is allocated and deallocated
+\item The next section only addresses how to move memory between different compute resources.
+\item Movement can be asynchronous as long as it is available when it is used by the compute resource
+\item Managing memory lifetime is seen as a separate problem.
+\end{itemize}
+}
+
+\subsection{Zero-Copy Memory}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item that there is a way to move memory content between different physical memory locations.
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item values are read by another compute resource and sent directly via the interconnect to the consuming compute resource
+\item the other way round for writing to memory.
+\end{itemize}
+}
+
+
+\subsection{Explicit Memory Management}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item that there is a way to move memory content between different physical memory locations.
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item Explicit memory management means the user has to specify when to move which memory to what memory location.
+\item Drivers adhere to the order memory movement and compute operations are given in
+\end{itemize}
+}
+
+\subsection{Page Migration}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item Memory in computers is organized in memory pages and virtual addresses.
+\item Which physical address a virtual address resides in is runtime dependent.
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item There exist multiple ways of resolving which physical location a page currently resides in.
+\item Pages can be moved to another physical memory that is accessible by the requesting compute resource
+\item This works via looking up the address in a address translation table and moving the page to a memory the compute resource can access
+\item differentiate to unified memory here!
+\item Do we need to also discuss that this can be just copying the data and not the page?
+\item Pages stay where they are moved?
+\item There is a unified address table that maps to all physical hardware memory locations.
+\end{itemize}
+}
+
+\subsubsection{Address Translation in Hardware}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item Addresses need to be translated to pages and the pages need to be located.
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item Hardware address translation allows a compute resource to efficiently compute the page address of a memory address.
+\item The driver can trigger a page migration if necessary.
+\end{itemize}
+}
+
+\subsubsection{Address Translation in Software}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item Addresses need to be translated to pages and the pages need to be located.
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item Software address translation does not require specialized hardware and thus can be activated for older hardware by modifying driver and os implementation details.
+\end{itemize}
+}
+
+\subsection{Unified Memory}
+\gist{
+  Prior Knowledge:
+\begin{itemize}
+\item Unified virtual address spaces.
+\end{itemize}
+  What is introduced in this chapter:
+\begin{itemize}
+\item Unified memory refers to hardware memory that can be directly accessed by all compute resources.
+\item Also uses Unified virtual addresses.
+\end{itemize}
+}
+
+\section{Kokkos' Memory Management Interface}
+
+
 
 \section{GH200}
 \import{./src_plots/}{vector_ping_pong_gh200.tex}

--- a/papers/hmm_paper/main.tex
+++ b/papers/hmm_paper/main.tex
@@ -5,6 +5,7 @@
 \usepackage{amsmath}
 \usepackage{hyperref}
 \usepackage{import}
+\usepackage{xcolor}
 
 \usepackage{subfig}
 \usepackage{graphicx}
@@ -18,6 +19,19 @@
 \tikzexternalize
 \tikzsetexternalprefix{plots/}
 %\tikzset{external/force remake}
+%%%%%%%%%%%%%%%%%%%%%%% PGFPLOTS DEFAULTS
+\pgfplotstableset{col sep=comma}
+\pgfplotstableset{header=false}
+
+%%%%%%%%%%%%%%%%%%%%%%% COLORS
+\definecolor{KKLightGreen}{RGB}{35,248,222}
+\definecolor{KKGreen}{RGB}{30,140,153}
+\definecolor{KKDarkGreen}{RGB}{14,130,130}
+
+\definecolor{KKLightPurple}{RGB}{201,49,161}
+\definecolor{KKPurple}{RGB}{99,41,199}
+\definecolor{KKDarkPurple}{RGB}{25,23,123}
+
 
 \title{Influence of the Heterogenious Memory Management System on Kokkos Semantics }
 

--- a/papers/hmm_paper/src_plots/bak.tex
+++ b/papers/hmm_paper/src_plots/bak.tex
@@ -1,0 +1,124 @@
+\begin{figure}[!ht]
+\centering
+\begin{tikzpicture}
+	\begin{axis}[
+	name=picture0_0,
+	%title=Boundary layer velocity profile,
+	%xlabel={$u_{\mathrm{cg}}\, [\frac{m}{s}]$},
+%	xlabel={$u^{gc}_1\, [\frac{m}{s}]$},
+	ylabel={Collective $[\%]$},
+	width=\singleplotwidth,
+	height=\singleplotheight,
+%	width=0.87\columnwidth,
+	grid=major,
+	xmin=0,
+	xmax=65,
+	%ymin=-0.0000005,
+	%ymax=1,
+	%samples=50
+	%ytikslabels{,,}
+	%height=0.5\textwidth
+	]
+	%PP
+	\addplot[mark=none,color={black}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{2}} , col sep=comma]			{./data/lbm_gensim/power_63_1.25_pp.csv}; %\label{plt::Power::PP}
+%	\addplot[mark=none,solid,color={mordantred}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{2}} , col sep=comma]			{./data/lbm_gensim/power_63_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={mordantred}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{2}} , col sep=comma]			{./data/lbm_gensim/power_32_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={indiagreen}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{2}} , col sep=comma]			{./data/lbm_gensim/power_64_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={palatinateblue}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{2}} , col sep=comma]			{./data/lbm_gensim/power_128_1.25_lbm.csv};
+	\addplot[mark=o,only marks,solid,color={black!50!white}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{2}+26.35}]	{./data/flight_test/FV_2.dat};% \label{plt::power::fv}%coll
+	\end{axis}
+	\begin{axis}[
+	name=picture0_1,
+	at=(picture0_0.south east),
+	anchor=south west,
+	xshift=2cm,
+	%xshift=1.5cm,
+%	yshift=-5.265cm,
+	%title=Boundary layer velocity profile,
+	%xlabel={$u_{\mathrm{cg}}\, [\frac{m}{s}]$},
+%	xlabel={$u^{gc}_1\, [\frac{m}{s}]$},
+	ylabel={Pedal $[\%]$},
+	width=\singleplotwidth,
+	height=\singleplotheight,
+%	width=0.87\columnwidth,
+	grid=major,
+	xmin=0,
+	xmax=65,
+	%ymin=-0.0000005,
+	%ymax=1,
+	%samples=50
+	%ytikslabels{,,}
+	%height=0.5\textwidth
+	]
+		%PP
+	\addplot[mark=none,color={black}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{3}} , col sep=comma]			{./data/lbm_gensim/power_63_1.25_pp.csv}; %\label{plt::Power::PP}
+%	\addplot[mark=none,solid,color={mordantred}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{3}} , col sep=comma]			{./data/lbm_gensim/power_63_1.25_lbm.csv};
+\addplot[mark=none,solid,color={mordantred}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{3}} , col sep=comma]			{./data/lbm_gensim/power_32_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={indiagreen}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{3}} , col sep=comma]			{./data/lbm_gensim/power_64_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={palatinateblue}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{3}} , col sep=comma]			{./data/lbm_gensim/power_128_1.25_lbm.csv};
+	\addplot[mark=o,only marks,solid,color={black!50!white}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{3}}]	{./data/flight_test/FV_2.dat};% \label{plt::power::fv}%coll
+	\end{axis}
+%	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%SECOND ROW
+	\begin{axis}[
+	name=picture1_0,
+	at=(picture0_0.below south west),
+	anchor=above north west,
+%	yshift=-5.265cm,
+	%title=Boundary layer velocity profile,
+	%xlabel={$u_{\mathrm{cg}}\, [\frac{m}{s}]$},
+	xlabel={$u^{gc}_{1,g}  \,[\frac{m}{s}]$},
+	ylabel={Lateral $[\%]$},
+	width=\singleplotwidth,
+	height=\singleplotheight,
+%	width=0.87\columnwidth,
+	grid=major,
+	xmin=0,
+	xmax=65,
+	%ymin=-0.0000005,
+	%ymax=1,
+	%samples=50
+	%ytikslabels{,,}
+	%height=0.5\textwidth
+	]
+		%PP
+	\addplot[mark=none,color={black}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{4}} , col sep=comma]			{./data/lbm_gensim/power_63_1.25_pp.csv}; %\label{plt::Power::PP}
+%	\addplot[mark=none,solid,color={mordantred}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{4}} , col sep=comma]			{./data/lbm_gensim/power_63_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={mordantred}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{4}} , col sep=comma]			{./data/lbm_gensim/power_32_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={indiagreen}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{4}} , col sep=comma]			{./data/lbm_gensim/power_64_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={palatinateblue}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{4}} , col sep=comma]			{./data/lbm_gensim/power_128_1.25_lbm.csv};
+	\addplot[mark=o,only marks,solid,color={black!50!white}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{4}}]	{./data/flight_test/FV_2.dat};% \label{plt::power::fv}%coll
+	\end{axis}
+	\begin{axis}[
+	name=picture1_1,
+	at=(picture1_0.south east),
+	anchor=south west,
+	xshift=2cm,
+%	yshift=-5.265cm,
+	%title=Boundary layer velocity profile,
+	xlabel={$u^{gc}_{1,g} \, [\frac{m}{s}]$},
+	ylabel={Longitudinal $[\%]$},
+	width=\singleplotwidth,
+	height=\singleplotheight,
+%	width=0.87\columnwidth,
+	grid=major,
+	xmin=0,
+	xmax=65,
+	%ymin=-0.0000005,
+	%ymax=1,
+	%samples=50
+	%ytikslabels{,,}
+	%height=0.5\textwidth
+	]
+			%PP
+	\addplot[mark=none,color={black}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{5}} , col sep=comma]			{./data/lbm_gensim/power_63_1.25_pp.csv}; %\label{plt::Power::PP}
+%	\addplot[mark=none,solid,color={mordantred}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{5}} , col sep=comma]			{./data/lbm_gensim/power_63_1.25_lbm.csv};
+\addplot[mark=none,solid,color={mordantred}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{5}} , col sep=comma]			{./data/lbm_gensim/power_32_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={indiagreen}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{5}} , col sep=comma]			{./data/lbm_gensim/power_64_1.25_lbm.csv};
+	\addplot[mark=none,solid,color={palatinateblue}] table [x expr={\thisrowno{0}}, y expr={\thisrowno{5}} , col sep=comma]			{./data/lbm_gensim/power_128_1.25_lbm.csv};
+	\addplot[mark=o,only marks,solid,color={black!50!white}] table [x expr={\thisrowno{0}}, y expr={100-\thisrowno{5}}]	{./data/flight_test/FV_2.dat};% \label{plt::power::fv}%coll
+	\end{axis}
+\end{tikzpicture}
+\caption[Collective, pedal, lateral, and longitudinal cyclic input in trimmed forward flight]{Collective, pedal, lateral, and longitudinal cyclic input in trimmed forward flight obtained with the \gls{lrm} at reach factor $a=1.25$ with resolution $N^{LRM}=32$ (\protect\plotref{plt:general:mordantred}), $N^{LRM}=64$ (\protect\plotref{plt:general:indiagreen}), and $N^{LRM}=128$ (\protect\plotref{plt:general:palatinateblue}).
+Pitt-Peters model (\protect\plotref{plt:general:hs_black}), and flight test measurements (\protect\plotref{plt::freeflight::power::FT}) for comparison.}
+\label{fig:plot:inputs:res}
+\end{figure}%

--- a/papers/hmm_paper/src_plots/vector_ping_pong_gh200.tex
+++ b/papers/hmm_paper/src_plots/vector_ping_pong_gh200.tex
@@ -2,11 +2,12 @@
 \centering
 \begin{tikzpicture}
 \begin{semilogxaxis}[
+    width=\textwidth,
     log basis x = 2,
 	%x tick label style={
 	%	/pgf/number format/1000 sep=},
   ymin=0,
-  ymax=2000,
+  %ymax=2000,
   ylabel={Bandwith $[GB/s]$},
   xlabel={Vector size $[-]$},
 	enlargelimits=0.15,
@@ -18,29 +19,33 @@
   xtick=data,
 	%point meta=y *10^-7 % the displayed number
 ]
-	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result.csv};
-	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result.csv};
-	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result.csv};
+	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result_1.csv};
+	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result_1.csv};
+	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result_1.csv};
+	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result_1.csv};
+	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result_1.csv};
+	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result_1.csv};
 
 % \addplot
 	% coordinates {(1930,38e6) (1940,42e6)
 		% (1950,43e6) (1960,45e6) (1970,65e6)};
 
-\legend{device-hostpinned,device-new,device-managed}
+\legend{device-hostpinned,device-new,device-managed,new,malloc,managed}
 \end{semilogxaxis}
 \end{tikzpicture}
-\caption{bla}
+\caption{Stride 1}
 \end{figure}
 
 \begin{figure}[!ht]
 \centering
 \begin{tikzpicture}
 \begin{semilogxaxis}[
+    width=\textwidth,
     log basis x = 2,
 	%x tick label style={
 	%	/pgf/number format/1000 sep=},
   ymin=0,
-  ymax=2000,
+  %ymax=2000,
   ylabel={Bandwith $[GB/s]$},
   xlabel={Vector size $[-]$},
 	enlargelimits=0.15,
@@ -52,16 +57,58 @@
   xtick=data,
 	%point meta=y *10^-7 % the displayed number
 ]
-	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result.csv};
-	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result.csv};
-	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result.csv};
+
+	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result_32.csv};
+	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result_32.csv};
+	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result_32.csv};
+	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result_32.csv};
+	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result_32.csv};
+	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result_32.csv};
 
 % \addplot
 	% coordinates {(1930,38e6) (1940,42e6)
 		% (1950,43e6) (1960,45e6) (1970,65e6)};
 
-\legend{new,malloc,managed}
+\legend{device-hostpinned,device-new,device-managed,new,malloc,managed}
 \end{semilogxaxis}
 \end{tikzpicture}
-\caption{bla}
+\caption{Stride 32}
+\end{figure}
+
+\begin{figure}[!ht]
+\centering
+\begin{tikzpicture}
+\begin{semilogxaxis}[
+    width=\textwidth,
+    log basis x = 2,
+	%x tick label style={
+	%	/pgf/number format/1000 sep=},
+  ymin=0,
+  %ymax=2000,
+  ylabel={Bandwith $[GB/s]$},
+  xlabel={Vector size $[-]$},
+	enlargelimits=0.15,
+	legend style={at={(0.5,-0.25)},
+		anchor=north,legend columns=-1},
+	ybar=2pt,% configures `bar shift'
+	bar width=3pt,
+	%nodes near coords,
+  xtick=data,
+	%point meta=y *10^-7 % the displayed number
+]
+	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result_4.csv};
+	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result_4.csv};
+	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result_4.csv};
+	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result_4.csv};
+	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result_4.csv};
+	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result_4.csv};
+
+% \addplot
+	% coordinates {(1930,38e6) (1940,42e6)
+		% (1950,43e6) (1960,45e6) (1970,65e6)};
+
+\legend{device-hostpinned,device-new,device-managed,new,malloc,managed}
+\end{semilogxaxis}
+\end{tikzpicture}
+\caption{Stride 4}
 \end{figure}

--- a/papers/hmm_paper/src_plots/vector_ping_pong_gh200.tex
+++ b/papers/hmm_paper/src_plots/vector_ping_pong_gh200.tex
@@ -1,0 +1,67 @@
+\begin{figure}[!ht]
+\centering
+\begin{tikzpicture}
+\begin{semilogxaxis}[
+    log basis x = 2,
+	%x tick label style={
+	%	/pgf/number format/1000 sep=},
+  ymin=0,
+  ymax=2000,
+  ylabel={Bandwith $[GB/s]$},
+  xlabel={Vector size $[-]$},
+	enlargelimits=0.15,
+	legend style={at={(0.5,-0.25)},
+		anchor=north,legend columns=-1},
+	ybar=2pt,% configures `bar shift'
+	bar width=3pt,
+	%nodes near coords,
+  xtick=data,
+	%point meta=y *10^-7 % the displayed number
+]
+	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result.csv};
+	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result.csv};
+	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result.csv};
+
+% \addplot
+	% coordinates {(1930,38e6) (1940,42e6)
+		% (1950,43e6) (1960,45e6) (1970,65e6)};
+
+\legend{device-hostpinned,device-new,device-managed}
+\end{semilogxaxis}
+\end{tikzpicture}
+\caption{bla}
+\end{figure}
+
+\begin{figure}[!ht]
+\centering
+\begin{tikzpicture}
+\begin{semilogxaxis}[
+    log basis x = 2,
+	%x tick label style={
+	%	/pgf/number format/1000 sep=},
+  ymin=0,
+  ymax=2000,
+  ylabel={Bandwith $[GB/s]$},
+  xlabel={Vector size $[-]$},
+	enlargelimits=0.15,
+	legend style={at={(0.5,-0.25)},
+		anchor=north,legend columns=-1},
+	ybar=2pt,% configures `bar shift'
+	bar width=3pt,
+	%nodes near coords,
+  xtick=data,
+	%point meta=y *10^-7 % the displayed number
+]
+	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result.csv};
+	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result.csv};
+	\addplot+[] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result.csv};
+
+% \addplot
+	% coordinates {(1930,38e6) (1940,42e6)
+		% (1950,43e6) (1960,45e6) (1970,65e6)};
+
+\legend{new,malloc,managed}
+\end{semilogxaxis}
+\end{tikzpicture}
+\caption{bla}
+\end{figure}

--- a/papers/hmm_paper/src_plots/vector_ping_pong_gh200.tex
+++ b/papers/hmm_paper/src_plots/vector_ping_pong_gh200.tex
@@ -19,12 +19,12 @@
   xtick=data,
 	%point meta=y *10^-7 % the displayed number
 ]
-	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result_1.csv};
-	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result_1.csv};
-	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result_1.csv};
-	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result_1.csv};
-	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result_1.csv};
-	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result_1.csv};
+	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result_1_1_1.csv};
+	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result_1_1_1.csv};
+	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result_1_1_1.csv};
+	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result_1_1_1.csv};
+	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result_1_1_1.csv};
+	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result_1_1_1.csv};
 
 % \addplot
 	% coordinates {(1930,38e6) (1940,42e6)
@@ -36,6 +36,45 @@
 \caption{Stride 1}
 \end{figure}
 
+% \begin{figure}[!ht]
+% \centering
+% \begin{tikzpicture}
+% \begin{semilogxaxis}[
+    % width=\textwidth,
+    % log basis x = 2,
+	% %x tick label style={
+	% %	/pgf/number format/1000 sep=},
+  % ymin=0,
+  % %ymax=2000,
+  % ylabel={Bandwith $[GB/s]$},
+  % xlabel={Vector size $[-]$},
+	% enlargelimits=0.15,
+	% legend style={at={(0.5,-0.25)},
+		% anchor=north,legend columns=-1},
+	% ybar=2pt,% configures `bar shift'
+	% bar width=3pt,
+	% %nodes near coords,
+  % xtick=data,
+	% %point meta=y *10^-7 % the displayed number
+% ]
+
+	% \addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result_32_1_1.csv};
+	% \addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result_32_1_1.csv};
+	% \addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result_32_1_1.csv};
+	% \addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result_32_1_1.csv};
+	% \addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result_32_1_1.csv};
+	% \addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result_32_1_1.csv};
+
+% % \addplot
+	% % coordinates {(1930,38e6) (1940,42e6)
+		% % (1950,43e6) (1960,45e6) (1970,65e6)};
+
+% \legend{device-hostpinned,device-new,device-managed,new,malloc,managed}
+% \end{semilogxaxis}
+% \end{tikzpicture}
+% \caption{Stride 32}
+% \end{figure}
+
 \begin{figure}[!ht]
 \centering
 \begin{tikzpicture}
@@ -57,51 +96,12 @@
   xtick=data,
 	%point meta=y *10^-7 % the displayed number
 ]
-
-	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result_32.csv};
-	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result_32.csv};
-	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result_32.csv};
-	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result_32.csv};
-	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result_32.csv};
-	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result_32.csv};
-
-% \addplot
-	% coordinates {(1930,38e6) (1940,42e6)
-		% (1950,43e6) (1960,45e6) (1970,65e6)};
-
-\legend{device-hostpinned,device-new,device-managed,new,malloc,managed}
-\end{semilogxaxis}
-\end{tikzpicture}
-\caption{Stride 32}
-\end{figure}
-
-\begin{figure}[!ht]
-\centering
-\begin{tikzpicture}
-\begin{semilogxaxis}[
-    width=\textwidth,
-    log basis x = 2,
-	%x tick label style={
-	%	/pgf/number format/1000 sep=},
-  ymin=0,
-  %ymax=2000,
-  ylabel={Bandwith $[GB/s]$},
-  xlabel={Vector size $[-]$},
-	enlargelimits=0.15,
-	legend style={at={(0.5,-0.25)},
-		anchor=north,legend columns=-1},
-	ybar=2pt,% configures `bar shift'
-	bar width=3pt,
-	%nodes near coords,
-  xtick=data,
-	%point meta=y *10^-7 % the displayed number
-]
-	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result_4.csv};
-	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result_4.csv};
-	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result_4.csv};
-	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result_4.csv};
-	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result_4.csv};
-	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result_4.csv};
+	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-hostpinned_result_4_1_1.csv};
+	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-new_result_4_1_1.csv};
+	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/device-managed_result_4_1_1.csv};
+	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/new-none_result_4_1_1.csv};
+	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/malloc-none_result_4_1_1.csv};
+	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/GH200/managed-none_result_4_1_1.csv};
 
 % \addplot
 	% coordinates {(1930,38e6) (1940,42e6)

--- a/papers/hmm_paper/src_plots/vector_ping_pong_mi300a.tex
+++ b/papers/hmm_paper/src_plots/vector_ping_pong_mi300a.tex
@@ -1,0 +1,114 @@
+\begin{figure}[!ht]
+\centering
+\begin{tikzpicture}
+\begin{semilogxaxis}[
+    width=\textwidth,
+    log basis x = 2,
+	%x tick label style={
+	%	/pgf/number format/1000 sep=},
+  ymin=0,
+  %ymax=2000,
+  ylabel={Bandwith $[GB/s]$},
+  xlabel={Vector size $[-]$},
+	enlargelimits=0.15,
+	legend style={at={(0.5,-0.25)},
+		anchor=north,legend columns=-1},
+	ybar=2pt,% configures `bar shift'
+	bar width=3pt,
+	%nodes near coords,
+  xtick=data,
+	%point meta=y *10^-7 % the displayed number
+]
+	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/device-hostpinned_result_1_1_1.csv};
+	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/device-new_result_1_1_1.csv};
+	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/device-managed_result_1_1_1.csv};
+	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/new-none_result_1_1_1.csv};
+	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/malloc-none_result_1_1_1.csv};
+	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/managed-none_result_1_1_1.csv};
+
+% \addplot
+	% coordinates {(1930,38e6) (1940,42e6)
+		% (1950,43e6) (1960,45e6) (1970,65e6)};
+
+\legend{device-hostpinned,device-new,device-managed,new,malloc,managed}
+\end{semilogxaxis}
+\end{tikzpicture}
+\caption{Stride 1}
+\end{figure}
+
+% \begin{figure}[!ht]
+% \centering
+% \begin{tikzpicture}
+% \begin{semilogxaxis}[
+    % width=\textwidth,
+    % log basis x = 2,
+	% %x tick label style={
+	% %	/pgf/number format/1000 sep=},
+  % ymin=0,
+  % %ymax=2000,
+  % ylabel={Bandwith $[GB/s]$},
+  % xlabel={Vector size $[-]$},
+	% enlargelimits=0.15,
+	% legend style={at={(0.5,-0.25)},
+		% anchor=north,legend columns=-1},
+	% ybar=2pt,% configures `bar shift'
+	% bar width=3pt,
+	% %nodes near coords,
+  % xtick=data,
+	% %point meta=y *10^-7 % the displayed number
+% ]
+
+	% \addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/device-hostpinned_result_32_1_1.csv};
+	% \addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/device-new_result_32_1_1.csv};
+	% \addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/device-managed_result_32_1_1.csv};
+	% \addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/new-none_result_32_1_1.csv};
+	% \addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/malloc-none_result_32_1_1.csv};
+	% \addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/managed-none_result_32_1_1.csv};
+
+% % \addplot
+	% % coordinates {(1930,38e6) (1940,42e6)
+		% % (1950,43e6) (1960,45e6) (1970,65e6)};
+
+% \legend{device-hostpinned,device-new,device-managed,new,malloc,managed}
+% \end{semilogxaxis}
+% \end{tikzpicture}
+% \caption{Stride 32}
+% \end{figure}
+
+\begin{figure}[!ht]
+\centering
+\begin{tikzpicture}
+\begin{semilogxaxis}[
+    width=\textwidth,
+    log basis x = 2,
+	%x tick label style={
+	%	/pgf/number format/1000 sep=},
+  ymin=0,
+  %ymax=2000,
+  ylabel={Bandwith $[GB/s]$},
+  xlabel={Vector size $[-]$},
+	enlargelimits=0.15,
+	legend style={at={(0.5,-0.25)},
+		anchor=north,legend columns=-1},
+	ybar=2pt,% configures `bar shift'
+	bar width=3pt,
+	%nodes near coords,
+  xtick=data,
+	%point meta=y *10^-7 % the displayed number
+]
+	\addplot+[color=KKLightGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/device-hostpinned_result_4_1_1.csv};
+	\addplot+[color=KKGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/device-new_result_4_1_1.csv};
+	\addplot+[color=KKDarkGreen] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/device-managed_result_4_1_1.csv};
+	\addplot+[color=KKLightPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/new-none_result_4_1_1.csv};
+	\addplot+[color=KKPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/malloc-none_result_4_1_1.csv};
+	\addplot+[color=KKDarkPurple] table [x expr={\thisrowno{1}}, y expr={\thisrowno{5}/1000} , col sep=comma]			{./vector_ping_pong/MI300A/managed-none_result_4_1_1.csv};
+
+% \addplot
+	% coordinates {(1930,38e6) (1940,42e6)
+		% (1950,43e6) (1960,45e6) (1970,65e6)};
+
+\legend{device-hostpinned,device-new,device-managed,new,malloc,managed}
+\end{semilogxaxis}
+\end{tikzpicture}
+\caption{Stride 4}
+\end{figure}

--- a/papers/hmm_paper/vector_ping_pong/GH200/preprocess.py
+++ b/papers/hmm_paper/vector_ping_pong/GH200/preprocess.py
@@ -1,0 +1,138 @@
+import csv
+import statistics
+from typing import List, Union
+
+def process_and_average_csv(
+    input_filename: str,
+    data_column_index: int,
+    ignore_lines_count: int = 0
+):
+    """
+    Reads a CSV, ignores a specified number of initial lines,
+    parses the data column, computes the average, and writes it
+    to a new CSV file.
+
+    :param input_filename: The path to the input CSV file.
+    :param output_filename: The path to the output CSV file.
+    :param data_column_index: The zero-based index of the column containing the numbers.
+    :param ignore_lines_count: The number of lines to ignore at the start (e.g., header/metadata).
+    """
+
+    # --- 1. Read and Process the Input CSV ---
+    data_values: List[Union[int, float]] = []
+    skipped_count = 0
+
+    header_line = 0
+    data_line = 0
+
+    try:
+        with open(input_filename, mode='r', newline='', encoding='utf-8') as infile:
+            reader = csv.reader(infile)
+
+            # Ignore initial lines
+            for _ in range(ignore_lines_count):
+                try:
+                    header_line = next(reader)
+                    skipped_count += 1
+                except StopIteration:
+                    print(f"Warning: Only {skipped_count} lines were present, less than the {ignore_lines_count} requested to ignore.")
+                    break
+            
+            # Process the remaining lines
+            for row in reader:
+                if not row:  # Skip empty rows
+                    continue
+                
+                try:
+                    # Get the value from the specified column index
+                    data_line = row
+                    value_str = row[data_column_index].strip()
+                    
+                    # Convert to float (assuming numerical data)
+                    # Use a try-except block to handle non-numeric values gracefully
+                    data_values.append(float(value_str))
+                    
+                except IndexError:
+                    print(f"Warning: Row {reader.line_num} is too short (needs index {data_column_index}). Skipping.")
+                except ValueError:
+                    # Non-numeric value in the specified column
+                    print(f"Warning: Non-numeric value '{row[data_column_index]}' in row {reader.line_num}. Skipping.")
+    
+    except FileNotFoundError:
+        print(f"Error: Input file '{input_filename}' not found.")
+        return
+    except Exception as e:
+        print(f"An unexpected error occurred during reading: {e}")
+        return
+
+    # --- 2. Compute the Average ---
+    if not data_values:
+        print("Error: No valid numerical data was found to compute an average.")
+        average = None
+    else:
+        # Use the statistics module for a robust average calculation
+        average = statistics.mean(data_values)
+        print(f"Successfully processed {len(data_values)} data points.")
+        print(f"The computed average is: {average:.4f}")
+
+    out_line = data_line
+    if average is not None:
+        out_line[data_column_index] = average
+    else:
+        out_line[data_column_index]= 'N/A'
+
+    return [header_line,out_line]
+
+def write_to_csv(
+    output_filename: str,
+    header_line: list[str],
+    out_line: list[list]
+):
+
+    # --- 3. Write the Output CSV ---
+    try:
+        with open(output_filename, mode='w', newline='', encoding='utf-8') as outfile:
+            writer = csv.writer(outfile)
+            
+            # Write a header
+            writer.writerow(header_line)
+            
+            for line in out_line:
+                writer.writerow(line)
+        
+        print(f"Success: Average written to '{output_filename}'")
+
+    except Exception as e:
+        print(f"An error occurred during writing: {e}")
+
+
+# ==================================
+# --- Script Execution Example ---
+# ==================================
+
+def process_files(prefix: str):
+    #  sizes = [2**8,2**10,2**12,2**14,2**16,2**18,2**20,2**22,2**24,2**26,2**30]
+    sizes = [2**8,2**10,2**12,2**14,2**16,2**18,2**20,2**22,2**24]
+    # 1. Define your file names and parameters
+    INPUT_FILES = [];
+    for size in sizes:
+        INPUT_FILES.append(f'{prefix}_{size}_100_100.csv')
+
+    OUTPUT_FILE = f'{prefix}_result.csv'
+    DATA_COL_INDEX = 5  # Assuming the numbers are in the third column (index 2)
+    IGNORE_LINES = 49    # Assuming the first line is a header to ignore
+
+    header_line = []
+    out_lines = []
+    # 2. Run the function
+    for file in INPUT_FILES:
+        print(f'Procesing file: {file}')
+        [header_line,out_line] = process_and_average_csv(file, DATA_COL_INDEX, IGNORE_LINES)
+        out_lines.append(out_line)
+
+    write_to_csv(OUTPUT_FILE,header_line,out_lines)
+
+
+prefixes = ['device-hostpinned','device-new','device-managed','managed-none','new-none','malloc-none']
+for prefix in prefixes:
+    process_files(prefix)

--- a/papers/hmm_paper/vector_ping_pong/GH200/preprocess.py
+++ b/papers/hmm_paper/vector_ping_pong/GH200/preprocess.py
@@ -106,19 +106,15 @@ def write_to_csv(
         print(f"An error occurred during writing: {e}")
 
 
-# ==================================
-# --- Script Execution Example ---
-# ==================================
-
-def process_files(prefix: str):
+def process_files(prefix: str, stride: str):
     #  sizes = [2**8,2**10,2**12,2**14,2**16,2**18,2**20,2**22,2**24,2**26,2**30]
     sizes = [2**8,2**10,2**12,2**14,2**16,2**18,2**20,2**22,2**24]
     # 1. Define your file names and parameters
     INPUT_FILES = [];
     for size in sizes:
-        INPUT_FILES.append(f'{prefix}_{size}_100_100.csv')
+        INPUT_FILES.append(f'{prefix}_{size}_100_100_{stride}.csv')
 
-    OUTPUT_FILE = f'{prefix}_result.csv'
+    OUTPUT_FILE = f'{prefix}_result_{stride}.csv'
     DATA_COL_INDEX = 5  # Assuming the numbers are in the third column (index 2)
     IGNORE_LINES = 49    # Assuming the first line is a header to ignore
 
@@ -134,5 +130,7 @@ def process_files(prefix: str):
 
 
 prefixes = ['device-hostpinned','device-new','device-managed','managed-none','new-none','malloc-none']
-for prefix in prefixes:
-    process_files(prefix)
+strides = [1,2,4,8,16,32]
+for stride in strides:
+    for prefix in prefixes:
+        process_files(prefix, stride)

--- a/papers/hmm_paper/vector_ping_pong/GH200/preprocess.py
+++ b/papers/hmm_paper/vector_ping_pong/GH200/preprocess.py
@@ -107,7 +107,7 @@ def write_to_csv(
 
 
 def process_files(prefix: str, stride: str):
-    #  sizes = [2**8,2**10,2**12,2**14,2**16,2**18,2**20,2**22,2**24,2**26,2**30]
+    #  sizes = [2**8,2**10,2**12,2**14,2**16,2**18,2**20,2**22,2**24,2**26]
     sizes = [2**8,2**10,2**12,2**14,2**16,2**18,2**20,2**22,2**24]
     # 1. Define your file names and parameters
     INPUT_FILES = [];

--- a/papers/hmm_paper/vector_ping_pong/MI300A/preprocess.py
+++ b/papers/hmm_paper/vector_ping_pong/MI300A/preprocess.py
@@ -116,7 +116,7 @@ def process_files(hardware: str, prefix: str, stride: str, ping: str, pong: str)
 
     OUTPUT_FILE = f'{prefix}_result_{stride}_{ping}_{pong}.csv'
     DATA_COL_INDEX = 5  # Assuming the numbers are in the third column (index 2)
-    IGNORE_LINES = 50    # Assuming the first line is a header to ignore
+    IGNORE_LINES = 81    # Assuming the first line is a header to ignore
 
     header_line = []
     out_lines = []
@@ -129,7 +129,7 @@ def process_files(hardware: str, prefix: str, stride: str, ping: str, pong: str)
     write_to_csv(OUTPUT_FILE,header_line,out_lines)
 
 
-hardware = 'gh200'
+hardware = 'mi300a'
 prefixes = ['device-hostpinned','device-new','device-managed','managed-none','new-none','malloc-none']
 strides = [1,2,4,8,16,32]
 pings = [1]


### PR DESCRIPTION
Start of the Paper on HMM and Kokkos.
The main focus of the paper is the question: "In which circumstances is the way we currently teach (two allocations for host and device and explicit deep_copies) the fastest way to write performance portable code." Since HMM came up and was integrated into the toolchains by Nvidia and AMD, system allocations and implicit memory movement are an option. This might have benefits based on access patterns and data layouts as well as on the bytes per flop in kernels. Synchronization is still required to be done manually but depending on the algorithm and datasizes it might be negligible.

Includes benchmark Vector_ping_pong for benchmarking the impact of using two arrays (how we teach) vs using automatic page migration (via `new`, `malloc`, or `managed`).

TODO:

- [ ] Add Vector-Ping-Pong results
- [ ] Add other test cases (probably something like a stream benchmark)
- [ ] Structure of paper